### PR TITLE
Add minimal type conversion

### DIFF
--- a/src/converters/__mocks__/scalerConverter.js
+++ b/src/converters/__mocks__/scalerConverter.js
@@ -1,0 +1,3 @@
+const convertScaler = jest.fn();
+
+export default convertScaler;

--- a/src/converters/scalarConverter.test.ts
+++ b/src/converters/scalarConverter.test.ts
@@ -1,0 +1,24 @@
+import { DMMF } from '@prisma/generator-helper';
+
+import convertScalar from './scalarConverter';
+import { GraphQL, Prisma } from './types';
+
+describe('convertScalar', () => {
+  it.each(['String', 'Boolean', 'Int', 'Float'])('does nothing for %s', (type) => {
+    type T = 'String' | 'Boolean' | 'Int' | 'Float'
+
+    const field = {
+      type: Prisma[type as T],
+    };
+
+    expect(convertScalar(field as DMMF.Field)).toBe(GraphQL[type as T]);
+  });
+
+  it('converts Json -> String', () => {
+    const field = {
+      type: Prisma.Json,
+    };
+
+    expect(convertScalar(field as DMMF.Field)).toBe(GraphQL.String);
+  });
+});

--- a/src/converters/scalarConverter.ts
+++ b/src/converters/scalarConverter.ts
@@ -1,0 +1,41 @@
+import { DMMF } from '@prisma/generator-helper';
+
+import { GraphQL, Prisma, Rule } from './types';
+
+const rules: Rule[] = [
+  {
+    matcher: (field) => {
+      const { type } = field;
+
+      if (type === Prisma.Json) {
+        return true;
+      }
+
+      return false;
+    },
+    transformer: () => GraphQL.String,
+  },
+];
+
+const convertScalar = (field: DMMF.Field) => {
+  const initialType = field.type;
+
+  const convertedType = rules.reduce((type, {
+    matcher, transformer,
+  }: Rule): string => {
+    if (matcher(field)) {
+      return transformer(field);
+    }
+
+    // TODO
+    if (typeof type !== 'string') {
+      return type.name;
+    }
+
+    return type;
+  }, initialType);
+
+  return convertedType;
+};
+
+export default convertScalar;

--- a/src/converters/typeConverter.test.ts
+++ b/src/converters/typeConverter.test.ts
@@ -1,0 +1,16 @@
+import { DMMF } from '@prisma/generator-helper';
+
+import convertType from './typeConverter';
+import convertScalar from './scalarConverter';
+
+jest.mock('./scalarConverter');
+
+describe('typeConverter', () => {
+  it('calls other converters by field kind', () => {
+    const field = { kind: 'scalar' };
+
+    convertType(field as DMMF.Field);
+
+    expect(convertScalar).toBeCalledWith(field);
+  });
+});

--- a/src/converters/typeConverter.ts
+++ b/src/converters/typeConverter.ts
@@ -1,0 +1,15 @@
+import { DMMF } from '@prisma/generator-helper';
+import convertScalar from './scalarConverter';
+
+const convertType = (field: DMMF.Field) => {
+  const { kind } = field;
+
+  if (kind === 'scalar') {
+    return convertScalar(field);
+  }
+
+  // TODO
+  return '';
+};
+
+export default convertType;

--- a/src/converters/types.ts
+++ b/src/converters/types.ts
@@ -1,0 +1,29 @@
+import { DMMF } from '@prisma/generator-helper';
+
+enum GraphQL {
+  ID = 'ID',
+  Int = 'Int',
+  Float = 'Float',
+  String = 'String',
+  Boolean = 'Boolean',
+}
+
+enum Prisma {
+  Int = 'Int',
+  Float = 'Float',
+  String = 'String',
+  BigInt = 'BigInt',
+  Boolean = 'Boolean',
+  Decimal = 'Decimal',
+  DateTime = 'DateTime',
+  Json = 'Json',
+  Bytes = 'Bytes',
+  Unsupported = 'Unsupported'
+}
+
+type Rule = {
+  matcher: (field: DMMF.Field) => boolean
+  transformer: (field?: DMMF.Field) => string
+}
+
+export { GraphQL, Prisma, Rule };


### PR DESCRIPTION
We need type conversion from `PSL` to `SDL`.

So now, `typeConverter` is added for this.
It calls other converters such as `scalarConverter` based on `DMMF.Field.kind`.

We have minimal rules here. Rest will be gradually added.