### PR TITLE
Add addTypeModiflers

### DIFF
--- a/src/converters/addTypeModifiers.test.ts
+++ b/src/converters/addTypeModifiers.test.ts
@@ -1,0 +1,30 @@
+import { DMMF } from '@prisma/generator-helper';
+
+import { Prisma } from './types';
+import addTypeModifier from './addTypeModifiers';
+
+describe('addTypeModifier', () => {
+  it('adds [] for list type', () => {
+    expect(
+      addTypeModifier({ type: Prisma.String, isList: false } as DMMF.Field),
+    )
+      .toBe('String');
+
+    expect(
+      addTypeModifier({ type: Prisma.String, isList: true } as DMMF.Field),
+    )
+      .toBe('[String]');
+  });
+
+  it('adds ! for non-nullable type', () => {
+    expect(
+      addTypeModifier({ type: Prisma.String, isRequired: false } as DMMF.Field),
+    )
+      .toBe('String');
+
+    expect(
+      addTypeModifier({ type: Prisma.String, isRequired: true } as DMMF.Field),
+    )
+      .toBe('String!');
+  });
+});

--- a/src/converters/addTypeModifiers.ts
+++ b/src/converters/addTypeModifiers.ts
@@ -1,0 +1,17 @@
+import { DMMF } from '@prisma/generator-helper';
+
+const addTypeModifilers = (field: DMMF.Field) => {
+  const { isList, isRequired } = field;
+
+  if (isList) {
+    return `[${field.type}]`;
+  }
+
+  if (isRequired) {
+    return `${field.type}!`;
+  }
+
+  return field.type;
+};
+
+export default addTypeModifilers;


### PR DESCRIPTION
Since `Prisma` only supports `list` and `optional`([can't combine both](https://www.prisma.io/docs/concepts/components/prisma-schema/data-model#type-modifiers)), it is simple. 