### PR TITLE
Fix bug that multiple rules are not applied correctly.

### DIFF
--- a/src/converters/addTypeModifiers.test.ts
+++ b/src/converters/addTypeModifiers.test.ts
@@ -27,4 +27,11 @@ describe('addTypeModifier', () => {
     )
       .toBe('String!');
   });
+
+  it('add []! for non-nullable list', () => {
+    expect(
+      addTypeModifier({ type: Prisma.String, isRequired: true, isList: true } as DMMF.Field),
+    )
+      .toBe('[String]!');
+  });
 });

--- a/src/converters/addTypeModifiers.ts
+++ b/src/converters/addTypeModifiers.ts
@@ -1,17 +1,27 @@
 import { DMMF } from '@prisma/generator-helper';
 
+import rules from './rules/modifier';
+import { Rule } from './types';
+
 const addTypeModifilers = (field: DMMF.Field) => {
-  const { isList, isRequired } = field;
+  const initialType = field.type;
 
-  if (isList) {
-    return `[${field.type}]`;
-  }
+  const convertedType = rules.reduce((type, {
+    matcher, transformer,
+  }: Rule): string => {
+    if (matcher(field)) {
+      return transformer(field, type);
+    }
 
-  if (isRequired) {
-    return `${field.type}!`;
-  }
+    // TODO
+    if (typeof type !== 'string') {
+      return type.name;
+    }
 
-  return field.type;
+    return type;
+  }, initialType);
+
+  return convertedType;
 };
 
 export default addTypeModifilers;

--- a/src/converters/convertScalar.ts
+++ b/src/converters/convertScalar.ts
@@ -10,7 +10,7 @@ const convertScalar = (field: DMMF.Field) => {
     matcher, transformer,
   }: Rule): string => {
     if (matcher(field)) {
-      return transformer(field);
+      return transformer(field, type);
     }
 
     // TODO

--- a/src/converters/rules/modifier.ts
+++ b/src/converters/rules/modifier.ts
@@ -1,0 +1,26 @@
+import { DMMF } from '@prisma/generator-helper';
+import { Rule } from 'converters/types';
+
+const addBrasket = (field: DMMF.Field, type: DMMF.Field['type']) => `[${type}]`;
+const addExclamation = (field: DMMF.Field, type: DMMF.Field['type']) => `${type}!`;
+
+const rules: Rule[] = [
+  {
+    matcher: (field) => {
+      const { isList } = field;
+
+      return isList;
+    },
+    transformer: addBrasket,
+  },
+  {
+    matcher: (field) => {
+      const { isRequired } = field;
+
+      return isRequired;
+    },
+    transformer: addExclamation,
+  },
+];
+
+export default rules;

--- a/src/converters/types.ts
+++ b/src/converters/types.ts
@@ -23,7 +23,7 @@ enum Prisma {
 
 type Rule = {
   matcher: (field: DMMF.Field) => boolean
-  transformer: (field?: DMMF.Field) => string
+  transformer: (field: DMMF.Field, type: DMMF.Field['type']) => string
 }
 
 export { GraphQL, Prisma, Rule };

--- a/src/transpile.test.ts
+++ b/src/transpile.test.ts
@@ -32,7 +32,7 @@ const graphqlSchema = `
     email: String!
     id: ID!
     name: String
-    posts: [Post]
+    posts: [Post]!
   }
 `;
 


### PR DESCRIPTION
Before: Only last rule is applied.

After: 

It affects to all converter using rules. But, the actual change is made only for `addTypeModifiers`.
Because in `convertScalar`, only last rule is needed for desired output. (at least for now).

**Note that order of rules matters. We'll handle this afterwards.**