### PR TITLE
Initial support for generating scalar

### DIFF
--- a/src/__mocks__/store.js
+++ b/src/__mocks__/store.js
@@ -1,0 +1,5 @@
+const store = {
+  addScalar: jest.fn(),
+};
+
+export default store;

--- a/src/converters/convertScalar.test.ts
+++ b/src/converters/convertScalar.test.ts
@@ -1,7 +1,10 @@
 import { DMMF } from '@prisma/generator-helper';
 
+import { GraphQL, Prisma, Scalar } from './types';
 import convertScalar from './convertScalar';
-import { GraphQL, Prisma } from './types';
+import store from '../store';
+
+jest.mock('../store');
 
 describe('convertScalar', () => {
   it.each(['String', 'Boolean', 'Int', 'Float'])('does nothing for %s', (type) => {
@@ -36,6 +39,26 @@ describe('convertScalar', () => {
     };
 
     expect(convertScalar(field as DMMF.Field)).toBe(GraphQL.Float);
+  });
+
+  it('converts Bytes to ByteArray, and store it to store for generating scalar', () => {
+    const field = {
+      type: Prisma.Bytes,
+    };
+
+    expect(convertScalar(field as DMMF.Field)).toBe(Scalar.ByteArray);
+
+    expect(store.addScalar).toBeCalledWith(Scalar.ByteArray);
+  });
+
+  it('stores DateTime to store for generating scalar', () => {
+    const field = {
+      type: Prisma.DateTime,
+    };
+
+    expect(convertScalar(field as DMMF.Field)).toBe(Scalar.DateTime);
+
+    expect(store.addScalar).toBeCalledWith(Scalar.DateTime);
   });
 
   it('converts every type declared as @id to ID', () => {

--- a/src/converters/rules/scalar.ts
+++ b/src/converters/rules/scalar.ts
@@ -1,4 +1,7 @@
-import { GraphQL, Prisma, Rule } from 'converters/types';
+import {
+  GraphQL, Prisma, Rule, Scalar,
+} from 'converters/types';
+import store from '../../store';
 
 const rules: Rule[] = [
   {
@@ -36,6 +39,38 @@ const rules: Rule[] = [
       return false;
     },
     transformer: () => GraphQL.Float,
+  },
+  {
+    matcher: (field) => {
+      const { type } = field;
+
+      if (type === Prisma.Bytes) {
+        return true;
+      }
+
+      return false;
+    },
+    transformer: () => {
+      store.addScalar(Scalar.ByteArray);
+
+      return Scalar.ByteArray;
+    },
+  },
+  {
+    matcher: (field) => {
+      const { type } = field;
+
+      if (type === Prisma.DateTime) {
+        return true;
+      }
+
+      return false;
+    },
+    transformer: () => {
+      store.addScalar(Scalar.DateTime);
+
+      return Scalar.DateTime;
+    },
   },
   {
     matcher: (field) => {

--- a/src/converters/types.ts
+++ b/src/converters/types.ts
@@ -21,9 +21,16 @@ enum Prisma {
   Unsupported = 'Unsupported'
 }
 
+enum Scalar {
+  ByteArray = 'ByteArray',
+  DateTime = 'DateTime',
+}
+
 type Rule = {
   matcher: (field: DMMF.Field) => boolean
   transformer: (field: DMMF.Field, type: DMMF.Field['type']) => string
 }
 
-export { GraphQL, Prisma, Rule };
+export {
+  GraphQL, Prisma, Scalar, Rule,
+};

--- a/src/formatters/formatScalar.test.ts
+++ b/src/formatters/formatScalar.test.ts
@@ -1,0 +1,7 @@
+import formatScalar from './formatScalar';
+
+describe('formatScalar', () => {
+  it('formats the whole scalar', () => {
+    expect(formatScalar('User')).toBe('scalar User\n');
+  });
+});

--- a/src/formatters/formatScalar.ts
+++ b/src/formatters/formatScalar.ts
@@ -1,0 +1,3 @@
+const formatScalar = (name: string) => `scalar ${name}\n`;
+
+export default formatScalar;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,25 @@
+type T = {
+  scalars: string[]
+}
+
+class Store {
+  data: T;
+
+  constructor() {
+    this.data = { scalars: [] };
+  }
+
+  get scalars(): string[] {
+    return this.data.scalars;
+  }
+
+  addScalar(s: string) {
+    const previous = this.data.scalars;
+
+    this.data.scalars = [...previous, s];
+  }
+}
+
+const store = new Store();
+
+export default store;

--- a/src/transpile.test.ts
+++ b/src/transpile.test.ts
@@ -6,7 +6,7 @@ import { removeWhiteSpaces } from './utils';
 const prismaSchema = /* Prisma */ `
   model Post {
     authorId  Int?
-    content   String?
+    content   Bytes?
     id        Int     @default(autoincrement()) @id
     published Boolean @default(false)
     author    User?   @relation(fields: [authorId], references: [id])
@@ -21,8 +21,10 @@ const prismaSchema = /* Prisma */ `
 `;
 
 const graphqlSchema = `
+  scalar ByteArray
+
   type Post {
-    content: String
+    content: ByteArray
     id: ID!
     published: Boolean!
     author: User

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -4,9 +4,11 @@ import convertType from 'converters/convertType';
 import addTypeModifiers from 'converters/addTypeModifiers';
 
 import formatModel from 'formatters/formatModel';
+import formatScalar from 'formatters/formatScalar';
 import formatField from './formatters/formatField';
 
 import { DataModel } from './parse';
+import store from './store';
 
 const getFieldTypePair = (model: DMMF.Model) => {
   if (!model) {
@@ -55,13 +57,17 @@ const getFieldTypePair = (model: DMMF.Model) => {
 const transpile = (dataModel: DataModel) => {
   const { models, names } = dataModel;
 
-  const graphqlSchema = names.map((name) => {
+  const modelsOfSchema = names.map((name) => {
     const fields = getFieldTypePair(models[name]);
 
     return formatModel(name, fields);
   }).join('');
 
-  return graphqlSchema;
+  const scalarsOfSchema = store.data.scalars.map((scalar) => formatScalar(scalar)).join('');
+
+  const schema = scalarsOfSchema + modelsOfSchema;
+
+  return schema;
 };
 
 export default transpile;


### PR DESCRIPTION
This PR includes two things.

1. Prepare ground for generating `scalar`.
2. Support `ByteArray` and `DateTime`. (`Bytes` -> `scalar ByteArray`, DateTime -> `scalar DateTime`).