### PR TITLE
Fix duplicated scalar generating bug

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1,22 +1,22 @@
 type T = {
-  scalars: string[]
+  scalars: Set<string>
 }
 
 class Store {
-  data: T;
+  private data: T;
 
   constructor() {
-    this.data = { scalars: [] };
+    this.data = { scalars: new Set<string>() };
   }
 
   get scalars(): string[] {
-    return this.data.scalars;
+    const set = this.data.scalars;
+
+    return Array.from(set.values());
   }
 
   addScalar(s: string) {
-    const previous = this.data.scalars;
-
-    this.data.scalars = [...previous, s];
+    this.data.scalars.add(s);
   }
 }
 

--- a/src/transpile.test.ts
+++ b/src/transpile.test.ts
@@ -21,6 +21,7 @@ const prismaSchema = /* Prisma */ `
     email String  @unique
     id    Int     @default(autoincrement()) @id
     name  String?
+    detail Bytes?
     posts Post[]
   }
 `;
@@ -44,6 +45,7 @@ const graphqlSchema = `
     email: String!
     id: ID!
     name: String
+    detail: ByteArray
     posts: [Post]!
   }
 `;

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -67,7 +67,7 @@ const transpile = (dataModel: DataModel) => {
     });
   }).join('');
 
-  const scalarsOfSchema = store.data.scalars.map((scalar) => formatScalar(scalar)).join('');
+  const scalarsOfSchema = store.scalars.map((scalar) => formatScalar(scalar)).join('');
 
   const enumsOfSchema = Object.entries(enums).map(([name, anEnum]) => {
     const fields = anEnum.map(({ name: field }) => `\t${field}`);


### PR DESCRIPTION
Before : `store.data.scalar` is `string[]`. So generated scalars can be duplicated.
After: Use `Set` and solve problem.