### PR TITLE
Move extractScalars to extractors folder

### DIFF
--- a/src/extractors/extractScalars.test.ts
+++ b/src/extractors/extractScalars.test.ts
@@ -1,0 +1,55 @@
+import {PSL, Scalar} from '../converters/types';
+import extractScalars from './extractScalars';
+import {DataModel} from '../parse';
+
+describe('extractScalars', () => {
+  it('extracts DateTime, and ByteArray from DateTime, Bytes', () => {
+    const dataModel = {
+      names: ['name1', 'name2'],
+      models: {
+        name1: {
+          fields: [
+            {
+              type: PSL.DateTime,
+            },
+          ],
+        },
+
+        name2: {
+          fields: [
+            {
+              type: PSL.Bytes,
+            },
+          ],
+        },
+      },
+    };
+
+    expect(extractScalars(dataModel as unknown as DataModel)).toEqual([
+      Scalar.DateTime,
+      Scalar.ByteArray,
+    ]);
+  });
+
+  it('igores duplicates', () => {
+    const dataModel = {
+      names: ['name1'],
+      models: {
+        name1: {
+          fields: [
+            {
+              type: PSL.DateTime,
+            },
+            {
+              type: PSL.DateTime,
+            },
+          ],
+        },
+      },
+    };
+
+    expect(extractScalars(dataModel as unknown as DataModel)).toEqual([
+      Scalar.DateTime,
+    ]);
+  });
+});

--- a/src/extractors/extractScalars.ts
+++ b/src/extractors/extractScalars.ts
@@ -1,0 +1,28 @@
+import {DataModel} from '../parse';
+import {Scalar, PSL} from '../converters/types';
+
+const extractScalars = (dataModel: DataModel): string[] => {
+  const {models, names} = dataModel;
+
+  const scalars = new Set<string>();
+
+  names.forEach((name) => {
+    const model = models[name];
+
+    model.fields.forEach((field) => {
+      const {type} = field;
+
+      if (type === PSL.DateTime) {
+        scalars.add(Scalar.DateTime);
+      }
+
+      if (type === PSL.Bytes) {
+        scalars.add(Scalar.ByteArray);
+      }
+    });
+  });
+
+  return Array.from(scalars.values());
+};
+
+export default extractScalars;

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -1,9 +1,12 @@
-import {PSL, Scalar} from './converters/types';
-
 import {DMMF} from '@prisma/generator-helper';
+
 import {DataModel} from './parse';
+
+import extractScalars from './extractors/extractScalars';
+
 import addTypeModifiers from './converters/addTypeModifiers';
 import convertType from './converters/convertType';
+
 import formatDefinition from './formatters/formatDefinition';
 import formatField from './formatters/formatField';
 import formatScalar from './formatters/formatScalar';
@@ -35,10 +38,10 @@ const getFieldTypePair = (model: DMMF.Model): string[] => {
       return '';
     }
 
-    const transformers = [convertType, addTypeModifiers];
+    const steps = [convertType, addTypeModifiers];
 
-    const typeTransformedField = transformers.reduce((acc, transformer) => {
-      const type = transformer(acc);
+    const typeTransformedField = steps.reduce((acc, step) => {
+      const type = step(acc);
 
       return {...acc, type};
     }, field);
@@ -47,30 +50,6 @@ const getFieldTypePair = (model: DMMF.Model): string[] => {
   });
 
   return pairs;
-};
-
-const extractScalars = (dataModel: DataModel): string[] => {
-  const {models, names} = dataModel;
-
-  const scalars = new Set<string>();
-
-  names.forEach((name) => {
-    const model = models[name];
-
-    model.fields.forEach((field) => {
-      const {type} = field;
-
-      if (type === PSL.DateTime) {
-        scalars.add(Scalar.DateTime);
-      }
-
-      if (type === PSL.Bytes) {
-        scalars.add(Scalar.ByteArray);
-      }
-    });
-  });
-
-  return Array.from(scalars.values());
 };
 
 const transpile = (dataModel: DataModel): string => {


### PR DESCRIPTION
While working on #20 and 2nd of #22, I realize there are common pattern, `Extractor`. And I decided to manage them in `extractors` folder. I start with moving `extractScalars` from `transpile` in this PR. 

On the way of doing it, I realized that `extractScalars` does not have its test. (Although I check it is valid with `transpile.test.ts` in the journey of TDD). So I added it.