### PR TITLE
I added support for ignoring any model field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # GraphQL-Schema-Generator for Prisma
 
-
 [![CI](https://github.com/prisma-korea/graphql-schema-generator/actions/workflows/ci.yml/badge.svg)](https://github.com/prisma-korea/graphql-schema-generator/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/prisma-korea/graphql-schema-generator/branch/master/graph/badge.svg?token=H4VN0S3ES9)](https://codecov.io/gh/prisma-korea/graphql-schema-generator)
-
 
 Generate **GraphQL schema (SDL)** from **Prisma schema** using a custom Prisma generator.
 
@@ -30,6 +28,23 @@ generator graphql {
 
 4. Check `schema.graphql` in `./prisma/generated` 🎉
 
+To ignore any model field add `/// @render(IGNORE)` as comment to the field.
+e.g.
+
+```prisma
+model User {
+  id: ID! @id @unique
+  name: String!
+  password: String! /// @render(IGNORE)
+}
+```
+
+Password will be ignored when generating the schema.
+
 ## Contributing
 
 Any contributions are welcome. If you are interested, check out our [guidelines](https://github.com/prisma-korea/graphql-schema-generator/blob/master/CONTRIBUTING.md).
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,3 @@ Password will be ignored when generating the schema.
 ## Contributing
 
 Any contributions are welcome. If you are interested, check out our [guidelines](https://github.com/prisma-korea/graphql-schema-generator/blob/master/CONTRIBUTING.md).
-
-```
-
-```

--- a/src/transpile.test.ts
+++ b/src/transpile.test.ts
@@ -195,4 +195,46 @@ describe('transpile', () => {
 
     expect(transpile(model)).toBe(graphqlSchema);
   });
+
+  it('ignore fields with "/// @render(IGNORE)" comment', async () => {
+    const prismaSchema = /* Prisma */ `
+      model Post {
+        authorId  Int?
+        content   String?
+        id        Int     @default(autoincrement()) @id
+        published Boolean @default(false)
+        author    User?   @relation(fields: [authorId], references: [id])
+      }
+
+      model User {
+        email String  @unique
+        id    Int     @default(autoincrement()) @id
+        name  String?
+        detail String?
+        /// @render(IGNORE)
+        posts Post[]
+        password String? /// @render(IGNORE)
+      }
+    `;
+
+    const graphqlSchema = sdl(`
+      type Post {
+        content: String
+        id: ID!
+        published: Boolean!
+        author: User
+      }
+
+      type User {
+        email: String!
+        id: ID!
+        name: String
+        detail: String
+      }
+    `);
+
+    const model = await parse(prismaSchema);
+
+    expect(transpile(model)).toBe(graphqlSchema);
+  });
 });


### PR DESCRIPTION
I added support for ignoring any model field like `password` from the generated schema

```prisma
model User {
  id: ID! @id @unique
  name: String!
  password: String! /// @render(IGNORE)
}
```

Password will be ignored when generating the schema.