### PR TITLE
Change Rule['transformer'] type

### DIFF
--- a/src/converters/addTypeModifiers.ts
+++ b/src/converters/addTypeModifiers.ts
@@ -4,25 +4,18 @@ import {Rule} from './types';
 import rules from './rules/modifier';
 
 const addTypeModifiers = (
-  field: DMMF.Field,
+  initialField: DMMF.Field,
   model: DMMF.Model,
 ): string | DMMF.SchemaEnum | DMMF.OutputType | DMMF.SchemaArg => {
-  const initialType = field.type;
-
-  const convertedType = rules.reduce(
-    (type, {matcher, transformer}: Rule): string => {
+  const {type: convertedType} = rules.reduce(
+    (field, {matcher, transformer}: Rule): DMMF.Field => {
       if (matcher(field, model)) {
-        return transformer(field, type);
+        return transformer(field);
       }
 
-      // TODO
-      if (typeof type !== 'string') {
-        return type.name;
-      }
-
-      return type;
+      return field;
     },
-    initialType,
+    initialField,
   );
 
   return convertedType;

--- a/src/converters/convertScalar.ts
+++ b/src/converters/convertScalar.ts
@@ -4,25 +4,18 @@ import {Rule} from './types';
 import rules from './rules/scalar';
 
 const convertScalar = (
-  field: DMMF.Field,
+  initialField: DMMF.Field,
   model: DMMF.Model,
 ): string | DMMF.SchemaEnum | DMMF.OutputType | DMMF.SchemaArg => {
-  const initialType = field.type;
-
-  const convertedType = rules.reduce(
-    (type, {matcher, transformer}: Rule): string => {
+  const {type: convertedType} = rules.reduce(
+    (field, {matcher, transformer}: Rule): DMMF.Field => {
       if (matcher(field, model)) {
-        return transformer(field, type);
+        return transformer(field);
       }
 
-      // TODO
-      if (typeof type !== 'string') {
-        return type.name;
-      }
-
-      return type;
+      return field;
     },
-    initialType,
+    initialField,
   );
 
   return convertedType;

--- a/src/converters/rules/modifier.ts
+++ b/src/converters/rules/modifier.ts
@@ -1,11 +1,17 @@
 import {DMMF} from '@prisma/generator-helper';
 import {Rule} from '../types';
 
-const addBrasket = (field: DMMF.Field, type: DMMF.Field['type']): string =>
-  `[${type}]`;
+const addBrasket = (field: DMMF.Field): DMMF.Field => {
+  const {type} = field;
 
-const addExclamation = (_field: DMMF.Field, type: DMMF.Field['type']): string =>
-  `${type}!`;
+  return {...field, type: `[${type}]`};
+};
+
+const addExclamation = (field: DMMF.Field): DMMF.Field => {
+  const {type} = field;
+
+  return {...field, type: `${type}!`};
+};
 
 const rules: Rule[] = [
   {
@@ -18,13 +24,11 @@ const rules: Rule[] = [
 
       return isList;
     },
-    transformer: (field: DMMF.Field, type: DMMF.Field['type']) => {
-      const ret = [addExclamation, addBrasket, addExclamation].reduce(
-        (acc, cur) => cur(field, acc),
-        type,
+    transformer: (field) => {
+      return [addExclamation, addBrasket, addExclamation].reduce(
+        (acc, cur) => cur(acc),
+        field,
       );
-
-      return ret as string;
     },
   },
   {
@@ -33,7 +37,7 @@ const rules: Rule[] = [
 
       return !isList && isRequired;
     },
-    transformer: addExclamation,
+    transformer: (field) => addExclamation(field),
   },
 ];
 

--- a/src/converters/rules/scalar.ts
+++ b/src/converters/rules/scalar.ts
@@ -13,7 +13,7 @@ const rules: Rule[] = [
 
       return false;
     },
-    transformer: () => SDL.String,
+    transformer: (field) => ({...field, type: SDL.String}),
   },
   {
     matcher: (field) => {
@@ -25,7 +25,7 @@ const rules: Rule[] = [
 
       return false;
     },
-    transformer: () => SDL.Int,
+    transformer: (field) => ({...field, type: SDL.Int}),
   },
   {
     matcher: (field) => {
@@ -37,7 +37,7 @@ const rules: Rule[] = [
 
       return false;
     },
-    transformer: () => SDL.Float,
+    transformer: (field) => ({...field, type: SDL.Float}),
   },
   {
     matcher: (field) => {
@@ -49,7 +49,7 @@ const rules: Rule[] = [
 
       return false;
     },
-    transformer: () => Scalar.ByteArray,
+    transformer: (field) => ({...field, type: Scalar.ByteArray}),
   },
   {
     matcher: (field) => {
@@ -57,7 +57,7 @@ const rules: Rule[] = [
 
       return isId;
     },
-    transformer: () => SDL.ID,
+    transformer: (field) => ({...field, type: SDL.ID}),
   },
   {
     matcher: (field, model) => {
@@ -68,7 +68,7 @@ const rules: Rule[] = [
 
       return !idField && uniqueFields.length === 1 && isUnique;
     },
-    transformer: () => SDL.ID,
+    transformer: (field) => ({...field, type: SDL.ID}),
   },
 ];
 

--- a/src/converters/types.ts
+++ b/src/converters/types.ts
@@ -39,7 +39,7 @@ enum Definition {
 
 type Rule = {
   matcher: (field: DMMF.Field, model: DMMF.Model) => boolean;
-  transformer: (field: DMMF.Field, type: DMMF.Field['type']) => string;
+  transformer: (field: DMMF.Field) => DMMF.Field;
 };
 
 export type {Rule};


### PR DESCRIPTION
`Rule` is general type used in this project, which is for converting field. It is true it is mainly used for converting type in field, but I think this type better updated like 15a91b520c666c13b950fb0ea1f2314051326d82.

This is also for developing feature  mentioned in #34 and #46.


I updated type in 15a91b520c666c13b950fb0ea1f2314051326d82, and 5174a34cacc2bebd7b1a00058fed2c5393a23dfa is for updating existing code to use new type.