### PR TITLE
Modify convertType, convertScalar, addTypeModifiers to return field

### DIFF
--- a/src/converters/addTypeModifiers.test.ts
+++ b/src/converters/addTypeModifiers.test.ts
@@ -10,21 +10,23 @@ describe('addTypeModifier', () => {
         {type: PSL.String, isRequired: false} as DMMF.Field,
         {} as DMMF.Model,
       ),
-    ).toBe('String');
+    ).toEqual({type: PSL.String, isRequired: false});
 
     expect(
       addTypeModifier(
         {type: PSL.String, isRequired: true} as DMMF.Field,
         {} as DMMF.Model,
       ),
-    ).toBe('String!');
+    ).toEqual({type: 'String!', isRequired: true});
   });
 
   it('add [!]! for list', () => {
     const field = {type: PSL.String, isList: true, isRequired: true};
 
-    expect(addTypeModifier(field as DMMF.Field, {} as DMMF.Model)).toBe(
-      '[String!]!',
-    );
+    expect(addTypeModifier(field as DMMF.Field, {} as DMMF.Model)).toEqual({
+      type: '[String!]!',
+      isList: true,
+      isRequired: true,
+    });
   });
 });

--- a/src/converters/addTypeModifiers.ts
+++ b/src/converters/addTypeModifiers.ts
@@ -6,8 +6,8 @@ import rules from './rules/modifier';
 const addTypeModifiers = (
   initialField: DMMF.Field,
   model: DMMF.Model,
-): string | DMMF.SchemaEnum | DMMF.OutputType | DMMF.SchemaArg => {
-  const {type: convertedType} = rules.reduce(
+): DMMF.Field => {
+  const newField = rules.reduce(
     (field, {matcher, transformer}: Rule): DMMF.Field => {
       if (matcher(field, model)) {
         return transformer(field);
@@ -18,7 +18,7 @@ const addTypeModifiers = (
     initialField,
   );
 
-  return convertedType;
+  return newField;
 };
 
 export default addTypeModifiers;

--- a/src/converters/convertScalar.test.ts
+++ b/src/converters/convertScalar.test.ts
@@ -18,7 +18,7 @@ describe('convertScalar', () => {
           field as DMMF.Field,
           {fields: []} as unknown as DMMF.Model,
         ),
-      ).toBe(SDL[type as T]);
+      ).toEqual(field as DMMF.Field);
     },
   );
 
@@ -29,7 +29,7 @@ describe('convertScalar', () => {
 
     expect(
       convertScalar(field as DMMF.Field, {fields: []} as unknown as DMMF.Model),
-    ).toBe(SDL.String);
+    ).toEqual({...field, type: SDL.String});
   });
 
   it('converts BigInt to Int', () => {
@@ -39,7 +39,7 @@ describe('convertScalar', () => {
 
     expect(
       convertScalar(field as DMMF.Field, {fields: []} as unknown as DMMF.Model),
-    ).toBe(SDL.Int);
+    ).toEqual({...field, type: SDL.Int});
   });
 
   it('converts Decimal to Float', () => {
@@ -49,7 +49,7 @@ describe('convertScalar', () => {
 
     expect(
       convertScalar(field as DMMF.Field, {fields: []} as unknown as DMMF.Model),
-    ).toBe(SDL.Float);
+    ).toEqual({...field, type: SDL.Float});
   });
 
   it('converts Bytes to ByteArray', () => {
@@ -59,7 +59,7 @@ describe('convertScalar', () => {
 
     expect(
       convertScalar(field as DMMF.Field, {fields: []} as unknown as DMMF.Model),
-    ).toBe(Scalar.ByteArray);
+    ).toEqual({...field, type: Scalar.ByteArray});
   });
 
   it('converts every type declared as @id to ID', () => {
@@ -68,28 +68,28 @@ describe('convertScalar', () => {
         {type: PSL.String, isId: false} as DMMF.Field,
         {fields: []} as unknown as DMMF.Model,
       ),
-    ).toBe(SDL.String);
+    ).toEqual({type: SDL.String, isId: false});
 
     expect(
       convertScalar(
         {type: PSL.Json, isId: false} as DMMF.Field,
         {fields: []} as unknown as DMMF.Model,
       ),
-    ).toBe(SDL.String);
+    ).toEqual({type: SDL.String, isId: false});
 
     expect(
       convertScalar(
         {type: PSL.String, isId: true} as DMMF.Field,
         {fields: []} as unknown as DMMF.Model,
       ),
-    ).toBe(SDL.ID);
+    ).toEqual({type: SDL.ID, isId: true});
 
     expect(
       convertScalar(
         {type: PSL.Json, isId: true} as DMMF.Field,
         {fields: []} as unknown as DMMF.Model,
       ),
-    ).toBe(SDL.ID);
+    ).toEqual({type: SDL.ID, isId: true});
   });
 
   it('converts solo @unique to ID if no @id exists', () => {
@@ -104,7 +104,7 @@ describe('convertScalar', () => {
           ],
         } as DMMF.Model,
       ),
-    ).toBe(SDL.ID);
+    ).toEqual({type: SDL.ID, isUnique: true, isId: false});
   });
 
   it('does nothing for multiple @unique even if no @id exists', () => {
@@ -119,6 +119,6 @@ describe('convertScalar', () => {
           ],
         } as DMMF.Model,
       ),
-    ).toBe(PSL.String);
+    ).toEqual({type: PSL.String, isUnique: true, isId: false});
   });
 });

--- a/src/converters/convertScalar.ts
+++ b/src/converters/convertScalar.ts
@@ -6,8 +6,8 @@ import rules from './rules/scalar';
 const convertScalar = (
   initialField: DMMF.Field,
   model: DMMF.Model,
-): string | DMMF.SchemaEnum | DMMF.OutputType | DMMF.SchemaArg => {
-  const {type: convertedType} = rules.reduce(
+): DMMF.Field => {
+  const newField = rules.reduce(
     (field, {matcher, transformer}: Rule): DMMF.Field => {
       if (matcher(field, model)) {
         return transformer(field);
@@ -18,7 +18,7 @@ const convertScalar = (
     initialField,
   );
 
-  return convertedType;
+  return newField;
 };
 
 export default convertScalar;

--- a/src/converters/convertType.ts
+++ b/src/converters/convertType.ts
@@ -1,10 +1,7 @@
 import {DMMF} from '@prisma/generator-helper';
 import convertScalar from './convertScalar';
 
-const convertType = (
-  field: DMMF.Field,
-  model: DMMF.Model,
-): string | DMMF.SchemaEnum | DMMF.OutputType | DMMF.SchemaArg => {
+const convertType = (field: DMMF.Field, model: DMMF.Model): DMMF.Field => {
   const {kind} = field;
 
   if (kind === 'scalar') {
@@ -12,7 +9,7 @@ const convertType = (
   }
 
   // TODO
-  return field.type;
+  return field;
 };
 
 export default convertType;

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -43,9 +43,7 @@ const getTypeConvertedFields = (model: DMMF.Model): DMMF.Field[] => {
       const transformers = [convertType, addTypeModifiers];
 
       const typeConvertedField = transformers.reduce((acc, transformer) => {
-        const type = transformer(acc, model);
-
-        return {...acc, type};
+        return transformer(acc, model);
       }, field);
 
       return [...collected, typeConvertedField];


### PR DESCRIPTION
After #47, I noticed that `convertType, convertScalar, addTypeModifiers` better return `field`, not `type`.

It gives more power to `transformer`, which will shine with `custom rules` support.